### PR TITLE
Modify packer docker builder requires

### DIFF
--- a/JSON/packer/1.5/manifest.json
+++ b/JSON/packer/1.5/manifest.json
@@ -375,7 +375,18 @@
                         }
                     }, {
                         "type": "object",
-                        "required": ["commit", "discard", "export_path", "image", "message"],
+                        "oneOf": [
+                          {
+                            "required": ["commit"]
+                          },
+                          {
+                            "required": ["discard"]
+                          },
+                          {
+                            "required": ["export_path"]
+                          }
+                        ],
+                        "required": ["image", "message"],
                         "properties": {
                             "type": {
                                 "description": "Type is Docker.",


### PR DESCRIPTION
Per [the Packer docs, the docker builder]( https://www.packer.io/docs/builders/docker) may only have one of `commit`, `discard`, or `export_path` defined, so this PR granularizes the schema to only require one of those three. Both `image` and `message` are still required regardless of what the final disposition of the container is.

Many thanks for this helpful schema definition!